### PR TITLE
aenum 3.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "aenum" %}
-{% set version = "3.1.0" %}
-{% set sha256 = "87f0e9ef4f828578ab06af30e4d7944043bf4ecd3f4b7bd1cbe37e2173cde94a" %}
+{% set version = "3.1.5" %}
+{% set sha256 = "2ebad8590b6a0183c0d9893523b458edce987ae4533339c5ac185cfac32daf1a" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Update aenum to 3.1.5

Version change: bump version number from 3.1.0 to 3.1.5
Requirements from conda-forge: https://github.com/conda-forge/aenum-feedstock/blob/master/recipe/meta.yaml
Bug Tracker: new open issues https://github.com/ethanfurman/aenum/issues
Upstream setup.py:  https://github.com/ethanfurman/aenum/blob/master/setup.py

The package aenum is mentioned inside the packages:
dbf |

Actions:
1. No actions

Result:
- all-succeeded